### PR TITLE
Use standard Makefile variables to ease cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,35 +1,36 @@
 NAME=indicurses
-FLAGS=-Wint-to-pointer-cast -std=gnu99
+CFLAGS += -Wint-to-pointer-cast -std=gnu99
 SRC=./src/*.c
 INC=include
 DST=./lib
 LINK=-string -lncurses -lm
 LIB=libindicurses.a
+INSTALL_PREFIX ?= /usr/local
 
 TSTINC=./tests/include
 TST=./tests
 TSTS=./tests/*.c
 
 all:
-	gcc $(FLAGS) -I./$(INC) -c $(SRC)
-	ar rcs $(DST)/$(LIB) *.o
+	$(CC) $(CFLAGS) $(CPPFLAGS) -I./$(INC) -c $(SRC)
+	$(AR) rcs $(DST)/$(LIB) *.o
 	rm *.o
 	mkdir -p $(DST)/include
 	cat /dev/null >| $(DST)/include/$(NAME).h
 	find ./$(INC) -name "*.h" -exec cat {} > $(DST)/include/$(NAME).h \;
 
 testlib: $(SRC)
-	gcc -I$(TSTINC) -c $(SRC)
-	ar rcs $(TST)/lib/$(LIB) *.o
+	$(CC) $(CFLAGS) $(CPPFLAGS) -I$(TSTINC) -c $(SRC)
+	$(AR) rcs $(TST)/lib/$(LIB) *.o
 	rm *.o
 
 tests: testlib
-	$(foreach test, $(TSTS), gcc $(test) -o $(TST)/bin/$(test).bin
+	$(foreach test, $(TSTS), $(CC) $(CFLAGS) $(CPPFLAGS) $(test) -o $(TST)/bin/$(test).bin
 
 install:
 	@echo 'Installing the library'
-	cp $(DST)/include/*.h /usr/local/include
-	cp $(DST)/*.a /usr/local/lib
+	cp $(DST)/include/*.h $(INSTALL_PREFIX)/include
+	cp $(DST)/*.a $(INSTALL_PREFIX)/lib
 clean:
 	find ./ -iname "*.a" -exec rm {} \;
 	find ./ -iname "*.o" -exec rm {} \;


### PR DESCRIPTION
Signed-off-by: Mitchel Haan mitchel.haan@modustri.com
